### PR TITLE
Fix bug in matching image metadata

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -250,7 +250,7 @@ fn extract_json_ld_image(parsed: &Value) -> Option<String> {
 pub fn get_article_metadata(document: &Html, json_ld: Metadata) -> Metadata {
     let mut values: HashMap<String, String> = HashMap::new();
     let property_pattern = regex::Regex::new(
-        r"(?i)\s*(article|dc|dcterm|og|twitter)\s*:\s*(author|creator|description|published_time|title|site_name|image|image:url|image:secure_url)\s*"
+        r"(?i)\s*(article|dc|dcterm|og|twitter)\s*:\s*(author|creator|description|published_time|title|site_name|image:url|image:secure_url|image$)\s*"
     ).unwrap();
 
     let name_pattern = regex::Regex::new(


### PR DESCRIPTION
Fixed as [here](https://github.com/go-shiori/go-readability/blob/5db1dc9836f0dda58b8112d3a93141b25eeeb454/parser.go#L29)